### PR TITLE
show project cache usage stats in widget

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     include "com.enonic.xp:lib-content:${xpVersion}"
     include "com.enonic.xp:lib-context:${xpVersion}"
     include "com.enonic.xp:lib-io:${xpVersion}"
+    include "com.enonic.xp:lib-node:${xpVersion}"
     include "com.enonic.xp:lib-project:${xpVersion}"
     include "com.enonic.xp:lib-portal:${xpVersion}"
     include "com.enonic.xp:lib-project:${xpVersion}"

--- a/src/main/resources/admin/widgets/booster/booster.html
+++ b/src/main/resources/admin/widgets/booster/booster.html
@@ -65,6 +65,29 @@
                 </div>
             </div>
 
+            <table id="widget-booster-commonlycachedpaths">
+                <caption>Commonly Cached Paths</caption>
+                <thead>
+                    <tr>
+                        <!-- We put count before path so that when path is too long for the widget width, we still see both columns -->
+                        <th>Count</th>
+                        <th>Path</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {{#commonlyCachedPaths}}
+                    <tr>
+                        <td>{{docCount}}</td>
+                        <td>
+                            <details data-detailurl="{{pathStatsServiceUrl}}?path={{key}}">
+                                <summary>{{key}}</summary>
+                                <div class="detail-target"></div>
+                            </details>
+                        </td>
+                    </tr>
+                    {{/commonlyCachedPaths}}
+                </tbody>
+            </table>
 
             {{/isEnabled}}
 

--- a/src/main/resources/admin/widgets/booster/booster.js
+++ b/src/main/resources/admin/widgets/booster/booster.js
@@ -38,7 +38,12 @@ const getCommonlyCachedPaths = (project, numResults) => {
     const allCachedPaths = boosterRepo.query({
         start: 0,
         count: 0,
-        query: `project = '${project}'`,
+        query: {
+            'term': {
+                'field': 'project',
+                'value': project
+            }
+        },
         aggregations: {
             paths: {
                 terms: {

--- a/src/main/resources/assets/js/main.js
+++ b/src/main/resources/assets/js/main.js
@@ -156,6 +156,26 @@
         });
 
         confirmNoButton && confirmNoButton.addEventListener('click', () => hideConfirmation());
+
+        pathDetails.forEach(detailElement => {
+            detailElement.addEventListener('click', () => {
+                const detailTarget = detailElement.querySelector('.detail-target');
+                // Only load details once
+                if (detailElement.getAttribute('data-loaded') === 'true') {
+                    return;
+                }
+    
+                fetch(detailElement.getAttribute('data-detailurl'))
+                    .then(response => response.text())
+                    .then(html => {
+                        detailTarget.innerHTML = html;
+                        detailElement.setAttribute('data-loaded', 'true');
+                    })
+                    .catch(error => {
+                        console.error('Error fetching details:', error);
+                    });
+            });
+        });
     }
 
     const serviceUrl = document.currentScript.getAttribute('data-service-url');
@@ -173,6 +193,7 @@
     const confirmYesButton = document.getElementById('widget-booster-confirmation-button-yes');
     const confirmNoButton = document.getElementById('widget-booster-confirmation-button-no');
     const responseContainer = document.getElementById('widget-booster-action-response');
+    const pathDetails = document.querySelectorAll('#widget-booster-commonlycachedpaths details');
 
     initEventListeners();
 

--- a/src/main/resources/assets/styles/main.css
+++ b/src/main/resources/assets/styles/main.css
@@ -85,4 +85,22 @@
         font-style: italic;
         margin-top: 10px;
     }
+
+    table {
+        border-collapse: collapse;
+        text-align: left;
+        min-width: 100%; /* mitigates aggressive word-wrap on caption and cells */
+    }
+    caption {
+        font-weight: bold;
+        text-align: left;
+    }
+    th, td {
+        border: 1px solid lightgray;
+        padding: 4px 7px;
+    }
+
+    details summary {
+        cursor: pointer;
+    }
 }

--- a/src/main/resources/services/pathstats/pathstats.html
+++ b/src/main/resources/services/pathstats/pathstats.html
@@ -1,0 +1,17 @@
+<table>
+  <caption>Cached querystring params</caption>
+  <thead>
+    <tr>
+      <th>Param</th>
+      <th>Unique value count</th>
+    </tr>
+    </thead>
+    <tbody>
+      {{#uniqueParams}}
+      <tr>
+          <td>{{paramName}}</td>
+          <td>{{uniqueValuesCount}}</td>
+      </tr>
+      {{/uniqueParams}}
+    </tbody>
+</table>

--- a/src/main/resources/services/pathstats/pathstats.js
+++ b/src/main/resources/services/pathstats/pathstats.js
@@ -1,0 +1,111 @@
+const mustache = require('/lib/mustache');
+const portal = require('/lib/xp/portal');
+const nodeLib  = require('/lib/xp/node');
+
+function parseQueryString(queryString) {
+  if (!queryString) {
+    return null;
+  }
+
+  return queryString.split('&').reduce((acc, pair) => {
+    const parts = pair.split('=');
+    const key = parts[0];
+    const value = parts[1];
+    
+    if (!acc[key]) {
+      acc[key] = {};
+    }
+    
+    acc[key][value] = true;
+    return acc;
+  }, {});
+}
+
+const getUniqueParams = (urlBuckets) => {
+  const queryStrings = urlBuckets.map(url => url.key ? url.key.split('?')[1] : '');
+
+  const parsedQueryStrings = queryStrings.map(parseQueryString).filter((parsed) => {
+    return parsed !== null;
+  });
+  
+  let allParams = {};
+  parsedQueryStrings.forEach((parsed) => {
+    for (let param in parsed) {
+      if (parsed.hasOwnProperty(param)) {
+        allParams[param] = true;
+      }
+    }
+  });
+
+  let result = [];
+  for (let param in allParams) {
+    if (allParams.hasOwnProperty(param)) {
+      let uniqueValues = {};
+      parsedQueryStrings.forEach((parsed) => {
+        if (parsed[param]) {
+          for (let value in parsed[param]) {
+            if (parsed[param].hasOwnProperty(value)) {
+              uniqueValues[value] = true;
+            }
+          }
+        }
+      });
+      const uniqueValuesArray = Object.keys(uniqueValues);
+      
+      result.push({
+        paramName: param,
+        uniqueValuesCount: uniqueValuesArray.length
+      });
+      result.sort((a, b) => {
+        // Sort descending
+        return b.uniqueValuesCount - a.uniqueValuesCount;
+      });
+    }
+  }
+  
+  return result;
+}
+
+const renderPathStats = (req) => {
+  const view = resolve('pathstats.html');
+  const path = req.params.path;
+
+  const boosterRepo = nodeLib.connect({
+    repoId: 'com.enonic.app.booster',
+    branch: 'master'
+  });
+
+  const pathUrls = boosterRepo.query({
+    start: 0,
+    count: 0,
+    query: 'path = "' + path + '"',
+    aggregations: {
+      urls: {
+        terms: {
+          field: 'url',
+          size: 10000
+        }
+      }
+    }
+  });
+  
+  const uniqueParams = getUniqueParams(pathUrls.aggregations.urls.buckets);
+  
+  if (uniqueParams.length) {
+    return {
+      contentType: 'text/html',
+      body: mustache.render(view, {
+        assetsUri: portal.assetUrl({ path: ''}),
+        path,
+        uniqueParams
+      })
+    }
+  }
+
+  return {
+    contentType: 'text/html',
+    body: '<p>(no querystring params in cache)</p>'
+  };
+}
+
+exports.get = (req) => renderPathStats(req);

--- a/src/main/resources/services/pathstats/pathstats.js
+++ b/src/main/resources/services/pathstats/pathstats.js
@@ -78,7 +78,12 @@ const renderPathStats = (req) => {
   const pathUrls = boosterRepo.query({
     start: 0,
     count: 0,
-    query: 'path = "' + path + '"',
+    query: {
+      'term': {
+        'field': 'path',
+        'value': path
+      }
+    },
     aggregations: {
       urls: {
         terms: {


### PR DESCRIPTION
In order to help Booster users debug their cache configuration, the Booster widget in Content Studio now not only allows you to purge cache for the project, but it also shows cache usage statistics.

- Shows a table with up to 20 of the most cached paths that belong to the current project, sorted descending by number of cache entries.
- Each path has a details element that allows for drilling down into the cache for the current path, with how many cached variations there are for certain querystring parameters. This allows users to discover that an inconsequential parameter (e.g. `?sometrackingparam=abc123`) is filling up unnecessarily many cache entries when there is otherwise no change in rendered content between these variations.
- When each details element is expanded on mouse click, its details are fetched with AJAX, and only fetched upon first expansion attempt.