### PR TITLE
Allow exclude user agents from cache

### DIFF
--- a/src/main/java/com/enonic/app/booster/BoosterConfig.java
+++ b/src/main/java/com/enonic/app/booster/BoosterConfig.java
@@ -17,4 +17,6 @@ public @interface BoosterConfig
     String overrideHeaders() default "";
 
     String cacheMimeTypes() default "text/html, text/xhtml";
+
+    String excludeUserAgents() default "facebookexternalhit, LinkedInBot, Twitterbot, WhatsApp, TelegramBot, Slackbot, Discordbot, Applebot, Googlebot, Bingbot, YandexBot, DuckDuckBot, Baiduspider, Sogou, 360Spider, AhrefsBot, SemrushBot, MJ12bot, DotBot, BLEXBot, Screaming Frog SEO Spider, rogerbot, exabot, ia_archiver, archive.org_bot, Wget, curl, PostmanRuntime, Apache-HttpClient, Java, Python, Go-http-client, node-fetch, axios, okhttp";
 }

--- a/src/main/java/com/enonic/app/booster/BoosterConfig.java
+++ b/src/main/java/com/enonic/app/booster/BoosterConfig.java
@@ -18,5 +18,5 @@ public @interface BoosterConfig
 
     String cacheMimeTypes() default "text/html, text/xhtml";
 
-    String excludeUserAgents() default "facebookexternalhit, LinkedInBot, Twitterbot, WhatsApp, TelegramBot, Slackbot, Discordbot, Applebot, Googlebot, Bingbot, YandexBot, DuckDuckBot, Baiduspider, Sogou, 360Spider, AhrefsBot, SemrushBot, MJ12bot, DotBot, BLEXBot, Screaming Frog SEO Spider, rogerbot, exabot, ia_archiver, archive.org_bot, Wget, curl, PostmanRuntime, Apache-HttpClient, Java, Python, Go-http-client, node-fetch, axios, okhttp";
+    String excludeUserAgents() default "";
 }

--- a/src/main/java/com/enonic/app/booster/BoosterConfigParsed.java
+++ b/src/main/java/com/enonic/app/booster/BoosterConfigParsed.java
@@ -10,7 +10,8 @@ import java.util.stream.Stream;
 import com.enonic.app.booster.utils.SimpleCsvParser;
 
 public record BoosterConfigParsed(long cacheTtlSeconds, Set<String> excludeQueryParams, boolean disableCacheStatusHeader, int cacheSize,
-                                  Set<String> appsForceInvalidateOnInstall, Map<String, String> overrideHeaders, Set<String> cacheMimeTypes)
+                                  Set<String> appsForceInvalidateOnInstall, Map<String, String> overrideHeaders, Set<String> cacheMimeTypes,
+                                  Set<String> excludeUserAgents)
 {
     public static BoosterConfigParsed parse( BoosterConfig config )
     {
@@ -45,7 +46,14 @@ public record BoosterConfigParsed(long cacheTtlSeconds, Set<String> excludeQuery
             .filter( Predicate.not( String::isEmpty ) )
             .collect( Collectors.toUnmodifiableSet() );
 
+        var excludeUserAgents = SimpleCsvParser.parseLine( config.excludeUserAgents() )
+            .stream()
+            .map( String::trim )
+            .map( s -> s.toLowerCase( Locale.ROOT ) )
+            .filter( Predicate.not( String::isEmpty ) )
+            .collect( Collectors.toUnmodifiableSet() );
+
         return new BoosterConfigParsed( cacheTtlSeconds, excludeQueryParams, disableCacheStatusHeader, cacheSize, appsForceInvalidateOnInstall, overrideHeaders,
-                                        cacheMimeTypes );
+                                        cacheMimeTypes, excludeUserAgents );
     }
 }

--- a/src/main/java/com/enonic/app/booster/BoosterRequestFilter.java
+++ b/src/main/java/com/enonic/app/booster/BoosterRequestFilter.java
@@ -134,7 +134,9 @@ public class BoosterRequestFilter
                                                                          new StoreConditions.SiteConfigConditions(
                                                                              config.excludeQueryParams() )::check,
                                                                          new StoreConditions.ContentTypePreconditions(
-                                                                             config.cacheMimeTypes() )::check );
+                                                                             config.cacheMimeTypes() )::check,
+                                                                         new StoreConditions.UserAgentConditions(
+                                                                             config.excludeUserAgents() )::check );
 
             final CachingResponseWrapper cachingResponse = new CachingResponseWrapper( request, response, storeConditions::check,
                                                                                        res -> writeHeaders( res, stale

--- a/src/main/java/com/enonic/app/booster/StoreConditions.java
+++ b/src/main/java/com/enonic/app/booster/StoreConditions.java
@@ -1,6 +1,7 @@
 package com.enonic.app.booster;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -220,6 +221,39 @@ public class StoreConditions
                 return false;
             }
             LOG.debug( "Not cacheable because of incompatible content-type {}", responseContentType );
+            return true;
+        }
+    }
+
+    public static class UserAgentConditions
+    {
+        private final Set<String> excludeUserAgents;
+
+        public UserAgentConditions( final Set<String> excludeUserAgents )
+        {
+            this.excludeUserAgents = excludeUserAgents;
+        }
+
+        public boolean check( HttpServletRequest request, CachingResponse response )
+        {
+            final String userAgent = request.getHeader( "User-Agent" );
+            if ( userAgent == null || userAgent.trim().isEmpty() )
+            {
+                // If no user agent is present, we can cache it
+                return true;
+            }
+
+            final String userAgentLower = userAgent.toLowerCase( Locale.ROOT );
+
+            for ( final String excludedAgent : excludeUserAgents )
+            {
+                if ( userAgentLower.contains( excludedAgent ) )
+                {
+                    LOG.debug( "Not cacheable because User-Agent contains excluded pattern: {} (User-Agent: {})", excludedAgent, userAgent );
+                    return false;
+                }
+            }
+
             return true;
         }
     }

--- a/src/main/java/com/enonic/app/booster/StoreConditions.java
+++ b/src/main/java/com/enonic/app/booster/StoreConditions.java
@@ -227,11 +227,11 @@ public class StoreConditions
 
     public static class UserAgentConditions
     {
-        private final Set<String> excludeUserAgents;
+        private final Set<String> defaultExcludeUserAgents;
 
-        public UserAgentConditions( final Set<String> excludeUserAgents )
+        public UserAgentConditions( final Set<String> defaultExcludeUserAgents )
         {
-            this.excludeUserAgents = excludeUserAgents;
+            this.defaultExcludeUserAgents = defaultExcludeUserAgents;
         }
 
         public boolean check( HttpServletRequest request, CachingResponse response )
@@ -244,6 +244,17 @@ public class StoreConditions
             }
 
             final String userAgentLower = userAgent.toLowerCase( Locale.ROOT );
+
+            // First check site config for excluded user agents
+            final PortalRequest portalRequest = RequestAttributes.getPortalRequest( request );
+            final BoosterSiteConfig siteConfig = BoosterSiteConfig.getSiteConfig( portalRequest );
+
+            Set<String> excludeUserAgents = defaultExcludeUserAgents;
+            if ( siteConfig != null && siteConfig.excludeUserAgents != null && !siteConfig.excludeUserAgents.isEmpty() )
+            {
+                // Use site configuration if available
+                excludeUserAgents = siteConfig.excludeUserAgents;
+            }
 
             for ( final String excludedAgent : excludeUserAgents )
             {

--- a/src/main/resources/site/site.xml
+++ b/src/main/resources/site/site.xml
@@ -36,6 +36,11 @@
             </input>
           </items>
         </item-set>
+        <input name="excludeUserAgent" type="TextLine">
+          <label>Excluded User Agent</label>
+          <occurrences minimum="0" maximum="0"/>
+          <help-text>User agents that should be excluded from caching. For example, "Googlebot", "facebookexternalhit", or "Twitterbot"</help-text>
+        </input>
       </items>
     </field-set>
   </form>

--- a/src/test/java/com/enonic/app/booster/BoosterRequestFilterTest.java
+++ b/src/test/java/com/enonic/app/booster/BoosterRequestFilterTest.java
@@ -4,6 +4,7 @@ import java.io.ByteArrayOutputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import javax.servlet.FilterChain;
 import javax.servlet.RequestDispatcher;
@@ -176,7 +177,7 @@ class BoosterRequestFilterTest
         {
             when( cacheStore.generateCacheKey( "https://example.com/site/repo/branch/s" ) ).thenCallRealMethod();
             when( cacheStore.get( "1ddd92089d02d31e68f1c6db45db255c" ) ).thenReturn( null );
-            when( BoosterSiteConfig.getSiteConfig( any() ) ).thenReturn( new BoosterSiteConfig( null, null, List.of() ) );
+            when( BoosterSiteConfig.getSiteConfig( any() ) ).thenReturn( new BoosterSiteConfig( null, null, List.of(), Set.of() ) );
             doAnswer( invocation -> {
                 HttpServletResponse response = invocation.getArgument( 1, HttpServletResponse.class );
                 response.getOutputStream(); // simulate call, otherwise response won't be cacheable

--- a/src/test/java/com/enonic/app/booster/StoreConditionsTest.java
+++ b/src/test/java/com/enonic/app/booster/StoreConditionsTest.java
@@ -341,6 +341,66 @@ class StoreConditionsTest
         assertTrue( storeConditions.check( request, response ) );
     }
 
+    @Test
+    void storeConditions_userAgent_facebookBot()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)" );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertFalse( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_linkedInBot()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)" );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertFalse( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_normalBrowser()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertTrue( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_null()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( null );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertTrue( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_empty()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "" );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertTrue( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_caseInsensitive()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "FACEBOOKEXTERNALHIT/1.1" );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        assertFalse( storeConditions.check( request, response ) );
+    }
+
     private static ResponseFreshness freshFreshness()
     {
         return new ResponseFreshness( null, null, false, false, false, Instant.now(), null );

--- a/src/test/java/com/enonic/app/booster/StoreConditionsTest.java
+++ b/src/test/java/com/enonic/app/booster/StoreConditionsTest.java
@@ -345,6 +345,7 @@ class StoreConditionsTest
     void storeConditions_userAgent_facebookBot()
     {
         when( request.getHeader( "User-Agent" ) ).thenReturn( "facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)" );
+        when( request.getAttribute( PortalRequest.class.getName() ) ).thenReturn( null );
 
         final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
 
@@ -355,6 +356,7 @@ class StoreConditionsTest
     void storeConditions_userAgent_linkedInBot()
     {
         when( request.getHeader( "User-Agent" ) ).thenReturn( "LinkedInBot/1.0 (compatible; Mozilla/5.0; Apache-HttpClient +http://www.linkedin.com)" );
+        when( request.getAttribute( PortalRequest.class.getName() ) ).thenReturn( null );
 
         final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
 
@@ -365,6 +367,7 @@ class StoreConditionsTest
     void storeConditions_userAgent_normalBrowser()
     {
         when( request.getHeader( "User-Agent" ) ).thenReturn( "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36" );
+        when( request.getAttribute( PortalRequest.class.getName() ) ).thenReturn( null );
 
         final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
 
@@ -395,9 +398,24 @@ class StoreConditionsTest
     void storeConditions_userAgent_caseInsensitive()
     {
         when( request.getHeader( "User-Agent" ) ).thenReturn( "FACEBOOKEXTERNALHIT/1.1" );
+        when( request.getAttribute( PortalRequest.class.getName() ) ).thenReturn( null );
 
         final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
 
+        assertFalse( storeConditions.check( request, response ) );
+    }
+
+    @Test
+    void storeConditions_userAgent_usesEmptySiteConfig()
+    {
+        when( request.getHeader( "User-Agent" ) ).thenReturn( "facebookexternalhit/1.1" );
+
+        final PortalRequest portalRequest = new PortalRequest();
+        when( request.getAttribute( PortalRequest.class.getName() ) ).thenReturn( portalRequest );
+
+        final var storeConditions = new StoreConditions.UserAgentConditions( Set.of( "facebookexternalhit", "linkedinbot", "twitterbot" ) );
+
+        // Should fall back to default exclude list when site config is null or empty
         assertFalse( storeConditions.check( request, response ) );
     }
 


### PR DESCRIPTION
I have a case where a content is private (the user needs to be logged in to access the page) but the client requested that the SEO Metafields were visible to User-Agents in the social media preview feature.

This code adds a TextLine with multiple occurrences to site config where we can define which User-Agents requests should avoid to be cached.