### PR TITLE
Bump lib-mustache to XP8 SNAPSHOT

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,7 @@ mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockitoVersio
 mockito-core = { module = "org.mockito:mockito-core" }
 mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
 
-lib-mustache = { module = "com.enonic.lib:lib-mustache", version = "2.1.1" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version = "3.0.0-SNAPSHOT" }
 lib-license = { module = "com.enonic.lib:lib-license", version = "4.0.0-SNAPSHOT" }
 
 brotli4j-brotli4j = { module = "com.aayushatharva.brotli4j:brotli4j", version.ref = "brotli4jVersion" }


### PR DESCRIPTION
## Summary

`lib-mustache 2.1.1` is compiled against pre-XP8 APIs. Bump to the XP8 SNAPSHOT.

- `lib-mustache` 2.1.1 → 3.0.0-SNAPSHOT

Repo already uses `xp.enonicRepo("dev")` (Kotlin DSL), so no repo change needed.

## Test plan

- [ ] `./gradlew build --refresh-dependencies` resolves the SNAPSHOT and tests pass
- [ ] E2E smoke against XP 8